### PR TITLE
Restore library build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,41 @@ This API provides a way to interact with the application's core logic without di
 
 -   React 18+, TypeScript, Tailwind CSS, @google/genai, Browser Speech APIs, MediaRecorder API, Browser Camera APIs, FileReader API, Mermaid.js, react-markdown.
 
+## Using as a Component Library
+
+The components, hooks, and services can be compiled into a reusable library.
+
+1. Run `npm run build:lib` to generate the `dist/` folder.
+2. Install this package in another project and import what you need:
+
+```ts
+import { ChatWindow, ChatInput } from 'miagemchatstudio';
+```
+
+## Example Project
+
+An example Vite + React app is provided under `examples/basic-usage`.
+
+1. Build and pack the library:
+
+   ```bash
+   npm run build:lib
+   npm pack
+   ```
+
+   This creates `miagemchatstudio-0.0.0.tgz`.
+
+2. Inside `examples/basic-usage`, install the tarball and start the dev server:
+
+   ```bash
+   cd examples/basic-usage
+   npm install ../miagemchatstudio-0.0.0.tgz
+   npm install
+   npm run dev
+   ```
+
+The example will open a page showing `ChatWindow` and `ChatInput` working together.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -200,13 +200,13 @@ An example Vite + React app is provided under `examples/basic-usage`.
    npm pack
    ```
 
-   This creates `miagemchatstudio-0.0.0.tgz`.
+   This creates `miagemchatstudio-0.0.1.tgz`.
 
 2. Inside `examples/basic-usage`, install the tarball and start the dev server:
 
    ```bash
    cd examples/basic-usage
-   npm install ../miagemchatstudio-0.0.0.tgz
+   npm install ../miagemchatstudio-0.0.1.tgz
    npm install
    npm run dev
    ```

--- a/codex/ledgers/ledger-lib-flexible-2506251155.json
+++ b/codex/ledgers/ledger-lib-flexible-2506251155.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "2506251155",
+  "agents": ["♾️ William – Sourcewalker", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "userInput": "Please address any inline comments on the diff, as well as any additional instructions below.\nKeep working on making this flexible to import, carefully look at all parts of this Multi-Persona Chat to see what needs various modulation",
+  "narrative": "Polished library prep by adding exports mapping and toggling package privacy. Updated docs and example to reference version 0.0.1 with newline corrections, enabling easier npm publishing.",
+  "routing": {
+    "paths": ["package.json", "README.md", "examples/basic-usage/README.md", "examples/basic-usage/package.json", "narrative-map.md"],
+    "branch": "work",
+    "feature": "lib-flexible"
+  },
+  "scene": "Components can now be imported via an exports map, while example docs reference the new version for publishing readiness.",
+  "glyphSequence": "✨📦🧩"
+}

--- a/codex/ledgers/ledger-library-restore-2506251135.json
+++ b/codex/ledgers/ledger-library-restore-2506251135.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "2506251135",
+  "agents": ["♾️ William – Sourcewalker", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "userInput": "I imported the latest changes but it might have overwritten the work we started on making the component reusable, ready to be distributed to npmjs, look at the commit history about that before we made that branch from the main you will know what I mean then continue this preparation by restoring what is needed and keep working on that with this latest version.",
+  "narrative": "Restored the library build settings overwritten by the upstream import. Re-added npm entry points, TypeScript declarations, and the React plugin so the package can once again compile for distribution. Documented how to build and consume the library.",
+  "routing": {
+    "paths": ["package.json", "vite.config.ts", "README.md"],
+    "branch": "work",
+    "feature": "library-restore"
+  },
+  "scene": "The codebase regains its ability to build a reusable package, letting future developers import ChatWindow and ChatInput from npm.",
+  "glyphSequence": "🧠🌸🎸⚙️"
+}

--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -9,12 +9,12 @@ This example demonstrates consuming the **miagemchatstudio** package in a fresh 
    npm pack
    ```
    
-   This produces `miagemchatstudio-0.0.0.tgz`.
+   This produces `miagemchatstudio-0.0.1.tgz`.
 
 2. Inside this `examples/basic-usage` folder run:
 
    ```bash
-   npm install ../miagemchatstudio-0.0.0.tgz
+   npm install ../miagemchatstudio-0.0.1.tgz
    npm install
    npm run dev
    ```

--- a/examples/basic-usage/package.json
+++ b/examples/basic-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-usage",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -17,3 +17,11 @@ Added missing files after previous code generation.
 - Installed dependencies and fixed TypeScript build errors.
 - Introduced an example Vite app under `examples/basic-usage` demonstrating how to consume the library.
 - Expanded README with step-by-step instructions to run the example.
+
+## 7310822 imported latest version from jgwill/EchoThreads
+- Pulled in numerous updates across components and documentation.
+- Note indicated some library preparation work might have been overwritten.
+
+## <pending> restore library build settings
+- Reintroduced npm package entry points and React plugin.
+- Added documentation describing library usage again.

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -22,6 +22,6 @@ Added missing files after previous code generation.
 - Pulled in numerous updates across components and documentation.
 - Note indicated some library preparation work might have been overwritten.
 
-## <pending> restore library build settings
+## b643e65 restore library build settings
 - Reintroduced npm package entry points and React plugin.
 - Added documentation describing library usage again.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miagemchatstudio",
-  "private": true,
-  "version": "0.0.0",
+  "private": false,
+  "version": "0.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -28,5 +28,13 @@
     "@vitejs/plugin-react": "^4.5.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,17 @@
   "name": "miagemchatstudio",
   "private": true,
   "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:lib": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "react-dom": "^19.1.0",
@@ -17,6 +23,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.5.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, '.', '');
   return {
+    plugins: [react()],
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- restore `main` and `types` entry points in `package.json`
- bring back `build:lib` script and React type devDeps
- re-enable React plugin in `vite.config.ts`
- document how to build and consume the library in README
- add development ledger entry
- update narrative map

## Testing
- `npm install`
- `npm run build:lib`


------
https://chatgpt.com/codex/tasks/task_e_685bde4d16c48329b4286eae2dcf4952